### PR TITLE
Remove search results log file and corresponding code

### DIFF
--- a/ado_express/main.py
+++ b/ado_express/main.py
@@ -39,13 +39,7 @@ class Startup:
     def initialize_logging(self):
         if self.search_only:
             logging.info('Starting the search...')
-
-            if os.path.isfile(self.search_file_path):
-                with open(self.search_file_path, "a") as file:
-                    file.write(f"\n\nNew Search Results:\nSearched Date & Time:{self.datetime_now.strftime(self.time_format)}\n")
-            else:
-                with open(self.search_file_path, "a") as file:
-                    file.write(f"New Search Results:\nSearched Date & Time:{self.datetime_now.strftime(self.time_format)}\n")
+            logging.info(f"New Search Results:\nSearched Date & Time:{self.datetime_now.strftime(self.time_format)}\n")
         else:
             logging.info('Starting the update...')
         
@@ -58,7 +52,6 @@ class Startup:
         self.ms_authentication = MSAuthentication(environment_variables)
         self.release_finder = ReleaseFinder(self.ms_authentication, environment_variables)
         self.search_only = environment_variables.SEARCH_ONLY
-        self.search_file_path = constants.SEARCH_RESULTS_FILE_PATH
         self.via_env = environment_variables.VIA_ENV
         self.via_latest = environment_variables.VIA_ENV_LATEST_RELEASE
         self.query = environment_variables.QUERY

--- a/ado_express/packages/common/constants.py
+++ b/ado_express/packages/common/constants.py
@@ -6,5 +6,4 @@ class Constants:
     DEPLOYMENT_PLAN_FILE_PATH = os.path.join(ROOT_DIR,'../../files/deployment/deployment-plan.xlsx')
     DEPLOYMENT_PLAN_HEADERS = ['Project Name', 'Release Name', 'Release Number', 'Rollback Number', 'Crucial']
     LOG_FILE_PATH = os.path.join(ROOT_DIR,'../../files/logs/deployment.log')
-    SEARCH_RESULTS_FILE_PATH = os.path.join(ROOT_DIR,'../../files/search-results/search-results.log')
     SEARCH_RESULTS_DEPLOYMENT_PLAN_FILE_PATH = os.path.join(ROOT_DIR,'../../files/search-results/deployment-plan.xlsx')


### PR DESCRIPTION
- Search results log file was pretty much unused 
&
- There was no need for duplicate logs to separate search from deployment 
- So file and corresponding code was removed
- The logs written to it will not be written to universal log file
- Will close #46 