### PR TITLE
Add search via number endpoint & tests

### DIFF
--- a/ado_express/main.py
+++ b/ado_express/main.py
@@ -151,7 +151,7 @@ class Startup:
             return None
     
     def search_and_log_details_only(self, deployment_detail: DeploymentDetails):
-        self.release_finder.get_releases(deployment_detail, find_via_env=self.via_env)
+        return self.release_finder.get_releases(deployment_detail, find_via_env=self.via_env)
     
     def deploy(self, deployment_detail: DeploymentDetails):
         try:

--- a/ado_express/packages/common/models/release_details.py
+++ b/ado_express/packages/common/models/release_details.py
@@ -1,0 +1,25 @@
+import datetime
+
+
+class ReleaseDetails:
+    """
+    :param release_project_name:
+    :type release_project_name: str
+    :param release_definition:
+    :type release_definition: str
+    :param release_name:
+    :type release_name: str
+    :param release_env:
+    :type release_env: str
+    :param is_deployed:
+    :type is_deployed: bool
+    :param modified_on:
+    :type modified_on: str
+    """
+    def __init__(self, release_project_name: str, release_definition: str, release_name: str, release_env: str, is_deployed: bool, modified_on: datetime):
+        self.release_project_name = release_project_name
+        self.release_definition = release_definition
+        self.release_name = release_name
+        self.release_env = release_env
+        self.is_deployed = is_deployed
+        self.modified_on = modified_on

--- a/ado_express/packages/utils/asset_retrievers/release_finder/release_finder.py
+++ b/ado_express/packages/utils/asset_retrievers/release_finder/release_finder.py
@@ -7,6 +7,7 @@ from ado_express.packages.common.constants import Constants
 from ado_express.packages.common.enums import ReleaseEnvironmentStatuses
 from ado_express.packages.common.environment_variables import EnvironmentVariables
 from ado_express.packages.common.models import DeploymentDetails
+from ado_express.packages.common.models.release_details import ReleaseDetails
 
 class ReleaseFinder:
 
@@ -25,6 +26,7 @@ class ReleaseFinder:
 
     def find_matching_releases_via_name(self, releases, release_number, deployment_detail: DeploymentDetails):
         found = False
+        found_releases = []
 
         for release in releases:
             
@@ -34,8 +36,12 @@ class ReleaseFinder:
                 for env in release_to_check.environments:
                     logging.info(f"Release Definition: {deployment_detail.release_name}\t Release: {release_to_check.name}\t Stage: {env.name}\t Status: {env.status}\t Modified On: {env.modified_on}\n")            
                     found = True
-                
+                    
+                    found_releases.append(ReleaseDetails(deployment_detail.release_project_name, deployment_detail.release_name, release_to_check.name, env.name, env.status in ReleaseEnvironmentStatuses.Succeeded, env.modified_on))
+
         if not found: logging.info(f"\nNO RESULTS AVAILABLE - Release Definition: {deployment_detail.release_name}\n")
+
+        return found_releases
                 
     def find_matching_release_via_source_stage(self, releases, deployment_detail, rollback=False):
         environment_name_to_find = self.environment_variables.RELEASE_TARGET_ENV if rollback else self.environment_variables.VIA_ENV_SOURCE_NAME
@@ -115,7 +121,7 @@ class ReleaseFinder:
             else: 
                 release_number = deployment_detail.release_rollback
                 
-            self.find_matching_releases_via_name(releases, release_number, deployment_detail)
+            return self.find_matching_releases_via_name(releases, release_number, deployment_detail)
 
     def get_releases_dict_from_build_releases(self, release, release_name_split_key):
         environment_name_to_find = self.environment_variables.VIA_ENV_SOURCE_NAME

--- a/ado_express_api/api/search_views.py
+++ b/ado_express_api/api/search_views.py
@@ -42,7 +42,7 @@ def search_via_latest_release(request):
         startup_runners = Startup(run_configurations)
         deployment_details = []
 
-        #TODO Make async
+        #TODO Make concurrent
         for release_details in run_configurations.release_details:
             converted_release_details = ReleaseDetails(release_details['release_project_name'], release_details['release_name'], None, None, release_details['is_crucial'])
             
@@ -56,8 +56,11 @@ def search_via_latest_release(request):
             return Response(status=status.HTTP_200_OK, data={'releases': []})
     else:
         return Response(status=status.HTTP_400_BAD_REQUEST, data=f"Fields are invalid.\n{serializer.error_messages}")
-
-
+    
+@api_view(['POST'])
+def search_via_release_number(request):
+    pass
+    
 @api_view(['POST'])
 def search_via_query(request):
     serializer = RunConfigurationsSerializer(data=request.data)

--- a/ado_express_api/api/search_views.py
+++ b/ado_express_api/api/search_views.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import api_view
 
 from base.models.RunConfigurations import RunConfigurations
 from base.models.DeploymentDetails import DeploymentDetails
+from base.models.ReleaseDetails import ReleaseDetails
 from .serializers import RunConfigurationsSerializer, DeploymentDetailsSerializer
 import status
 from ado_express.main import Startup
@@ -59,7 +60,50 @@ def search_via_latest_release(request):
     
 @api_view(['POST'])
 def search_via_release_number(request):
-    pass
+    deployment_details = DeploymentDetailsSerializer()
+    deployment_details.set_required_fields_for_via_number()
+
+    serializer = RunConfigurationsSerializer(data=request.data)
+    serializer.fields['deployment_details'].child = deployment_details
+
+    # Fields required for via latest run
+    serializer.fields['deployment_details'].required = True
+    # Fields not required for via latest run
+    serializer.fields['search_only'].required = False
+    serializer.fields['via_env'].required = False
+    serializer.fields['via_env_latest_release'].required = False
+
+    if serializer.is_valid():
+        run_configurations = RunConfigurations(serializer.validated_data['explicit_release_values'], 
+                                               serializer.validated_data['crucial_release_definitions'], 
+                                               serializer.validated_data['organization_url'], 
+                                               serializer.validated_data['personal_access_token'], 
+                                               None, 
+                                               serializer.validated_data['release_name_format'], 
+                                               None,
+                                               True, # search_only
+                                               False, # via_env
+                                               False, # via_env_latest_release
+                                               None,
+                                               serializer.validated_data['deployment_details'])
+        
+        startup_runners = Startup(run_configurations)
+        release_details = []
+
+        #TODO Make concurrent
+        for deployment in run_configurations.deployment_details:
+            converted_deployment_details = DeploymentDetails(deployment['release_project_name'], deployment['release_name'], deployment['release_number'], None, deployment['is_crucial'])
+            
+            releases: list[ReleaseDetails] = startup_runners.search_and_log_details_only(converted_deployment_details)
+            
+            if releases: release_details.append(dict({'release_definition': deployment['release_name'], 'release_name': deployment['release_number'], 'results': [release.__dict__ for release in releases]}))
+
+        if release_details:
+            return Response(status=status.HTTP_200_OK, data={'releases': json.dumps(release_details, default=str)})
+        else:
+            return Response(status=status.HTTP_200_OK, data={'releases': []})
+    else:
+        return Response(status=status.HTTP_400_BAD_REQUEST, data=f"Fields are invalid.\n{serializer.error_messages}")
                     
 @api_view(['POST'])
 def search_via_query(request):
@@ -89,6 +133,9 @@ def search_via_query(request):
         startup_runners = Startup(run_configurations)
         deployment_details = startup_runners.get_deployment_details_from_query()
 
-        return Response(status=status.HTTP_200_OK, data={'releases': json.dumps([ob.__dict__ for ob in deployment_details])})
+        if deployment_details:
+            return Response(status=status.HTTP_200_OK, data={'releases': json.dumps([ob.__dict__ for ob in deployment_details])})
+        else:
+            return Response(status=status.HTTP_200_OK, data={'releases': []})
     else:
         return Response(status=status.HTTP_400_BAD_REQUEST, data=f"Fields are invalid.\n{serializer.error_messages}")

--- a/ado_express_api/api/search_views.py
+++ b/ado_express_api/api/search_views.py
@@ -3,21 +3,21 @@ from rest_framework.response import Response
 from rest_framework.decorators import api_view
 
 from base.models.RunConfigurations import RunConfigurations
-from base.models.ReleaseDetails import ReleaseDetails
-from .serializers import RunConfigurationsSerializer, ReleaseDetailsSerializer
+from base.models.DeploymentDetails import DeploymentDetails
+from .serializers import RunConfigurationsSerializer, DeploymentDetailsSerializer
 import status
 from ado_express.main import Startup
 
 @api_view(['POST'])
 def search_via_latest_release(request):
-    release_details = ReleaseDetailsSerializer()
-    release_details.set_required_fields_for_via_latest()
+    deployment_details = DeploymentDetailsSerializer()
+    deployment_details.set_required_fields_for_via_latest()
 
     serializer = RunConfigurationsSerializer(data=request.data)
-    serializer.fields['release_details'].child = release_details
+    serializer.fields['deployment_details'].child = deployment_details
 
     # Fields required for via latest run
-    serializer.fields['release_details'].required = True
+    serializer.fields['deployment_details'].required = True
     serializer.fields['release_target_env'].required = True
     serializer.fields['via_env_source_name'].required = True
     # Fields not required for via latest run
@@ -37,16 +37,16 @@ def search_via_latest_release(request):
                                                True, # via_env
                                                True, # via_env_latest_release
                                                serializer.validated_data['via_env_source_name'],
-                                               serializer.validated_data['release_details'])
+                                               serializer.validated_data['deployment_details'])
         
         startup_runners = Startup(run_configurations)
         deployment_details = []
 
         #TODO Make concurrent
-        for release_details in run_configurations.release_details:
-            converted_release_details = ReleaseDetails(release_details['release_project_name'], release_details['release_name'], None, None, release_details['is_crucial'])
+        for deployment in run_configurations.deployment_details:
+            converted_deployment_details = DeploymentDetails(deployment['release_project_name'], deployment['release_name'], None, None, deployment['is_crucial'])
             
-            release = startup_runners.get_deployment_detail_from_latest_release(converted_release_details)
+            release = startup_runners.get_deployment_detail_from_latest_release(converted_deployment_details)
             
             if release: deployment_details.append(release)
 
@@ -60,7 +60,7 @@ def search_via_latest_release(request):
 @api_view(['POST'])
 def search_via_release_number(request):
     pass
-    
+                    
 @api_view(['POST'])
 def search_via_query(request):
     serializer = RunConfigurationsSerializer(data=request.data)
@@ -84,7 +84,7 @@ def search_via_query(request):
                                                serializer.validated_data['via_env'], 
                                                serializer.validated_data['via_env_latest_release'],
                                                serializer.validated_data['via_env_source_name'],
-                                               serializer.validated_data['release_details'])
+                                               serializer.validated_data['deployment_details'])
         
         startup_runners = Startup(run_configurations)
         deployment_details = startup_runners.get_deployment_details_from_query()

--- a/ado_express_api/api/search_views.py
+++ b/ado_express_api/api/search_views.py
@@ -11,7 +11,6 @@ from ado_express.main import Startup
 @api_view(['POST'])
 def search_via_latest_release(request):
     release_details = ReleaseDetailsSerializer()
-    # Fields not required for via latest run
     release_details.set_required_fields_for_via_latest()
 
     serializer = RunConfigurationsSerializer(data=request.data)
@@ -21,7 +20,11 @@ def search_via_latest_release(request):
     serializer.fields['release_details'].required = True
     serializer.fields['release_target_env'].required = True
     serializer.fields['via_env_source_name'].required = True
-    print(serializer.initial_data)
+    # Fields not required for via latest run
+    serializer.fields['search_only'].required = False
+    serializer.fields['via_env'].required = False
+    serializer.fields['via_env_latest_release'].required = False
+
     if serializer.is_valid():
         run_configurations = RunConfigurations(serializer.validated_data['explicit_release_values'], 
                                                serializer.validated_data['crucial_release_definitions'], 
@@ -58,10 +61,13 @@ def search_via_latest_release(request):
 @api_view(['POST'])
 def search_via_query(request):
     serializer = RunConfigurationsSerializer(data=request.data)
+
     # Fields required for query run
     serializer.fields['queries'].required = True
     serializer.fields['release_target_env'].required = True
     serializer.fields['via_env'].required = True
+    # Fields not required for query run
+    serializer.fields['search_only'].required = False
 
     if serializer.is_valid():
         run_configurations = RunConfigurations(serializer.validated_data['explicit_release_values'], 

--- a/ado_express_api/api/serializers.py
+++ b/ado_express_api/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-class ReleaseDetailsSerializer(serializers.Serializer):
+class DeploymentDetailsSerializer(serializers.Serializer):
     release_project_name = serializers.CharField(max_length=200, required=True)
     release_name = serializers.CharField(max_length=200, required=True)
     release_number = serializers.IntegerField(min_value=0, required=True)
@@ -27,4 +27,4 @@ class RunConfigurationsSerializer(serializers.Serializer):
     via_env_source_name = serializers.CharField(max_length=200)
     via_env_latest_release = serializers.BooleanField()
     
-    release_details = serializers.ListSerializer(child=ReleaseDetailsSerializer())
+    deployment_details = serializers.ListSerializer(child=DeploymentDetailsSerializer())

--- a/ado_express_api/api/serializers.py
+++ b/ado_express_api/api/serializers.py
@@ -11,6 +11,9 @@ class ReleaseDetailsSerializer(serializers.Serializer):
         self.fields['release_number'].required = False
         self.fields['release_rollback'].required = False
 
+    def set_required_fields_for_via_number(self):
+        self.fields['release_rollback'].required = False
+
 class RunConfigurationsSerializer(serializers.Serializer):
     explicit_release_values = serializers.DictField()
     crucial_release_definitions = serializers.ListField(child = serializers.CharField(max_length=200))
@@ -19,7 +22,7 @@ class RunConfigurationsSerializer(serializers.Serializer):
     queries = serializers.ListField(child = serializers.CharField(max_length=200))
     release_name_format = serializers.CharField(max_length=200, required=True)
     release_target_env = serializers.CharField(max_length=200)
-    search_only = serializers.BooleanField(required=True)
+    search_only = serializers.BooleanField()
     via_env = serializers.BooleanField()
     via_env_source_name = serializers.CharField(max_length=200)
     via_env_latest_release = serializers.BooleanField()

--- a/ado_express_api/api/urls.py
+++ b/ado_express_api/api/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from . import search_views
 
 '''
-/run/query
+/run/via-query
 /run/via_latest
 /run/via_numbers
 
@@ -12,6 +12,6 @@ from . import search_views
 '''
 
 urlpatterns = [
-    path('search/query', search_views.search_via_query),
+    path('search/via-query', search_views.search_via_query),
     path('search/via-latest', search_views.search_via_latest_release)
 ]

--- a/ado_express_api/api/urls.py
+++ b/ado_express_api/api/urls.py
@@ -12,6 +12,7 @@ from . import search_views
 '''
 
 urlpatterns = [
-    path('search/via-query', search_views.search_via_query),
-    path('search/via-latest', search_views.search_via_latest_release)
+    path('search/via-latest', search_views.search_via_latest_release),
+    path('search/via-number', search_views.search_via_release_number),
+    path('search/via-query', search_views.search_via_query)
 ]

--- a/ado_express_api/base/models/DeploymentDetails.py
+++ b/ado_express_api/base/models/DeploymentDetails.py
@@ -1,4 +1,4 @@
-class ReleaseDetails:
+class DeploymentDetails:
     """
     :param release_project_name:
     :type release_project_name: str

--- a/ado_express_api/base/models/ReleaseDetails.py
+++ b/ado_express_api/base/models/ReleaseDetails.py
@@ -1,0 +1,25 @@
+import datetime
+
+
+class ReleaseDetails:
+    """
+    :param release_project_name:
+    :type release_project_name: str
+    :param release_definition:
+    :type release_definition: str
+    :param release_name:
+    :type release_name: str
+    :param release_env:
+    :type release_env: str
+    :param is_deployed:
+    :type is_deployed: bool
+    :param modified_on:
+    :type modified_on: str
+    """
+    def __init__(self, release_project_name: str, release_definition: str, release_name: str, release_env: str, is_deployed: bool, modified_on: datetime):
+        self.release_project_name = release_project_name
+        self.release_definition = release_definition
+        self.release_name = release_name
+        self.release_env = release_env
+        self.is_deployed = is_deployed
+        self.modified_on = modified_on

--- a/ado_express_api/base/models/RunConfigurations.py
+++ b/ado_express_api/base/models/RunConfigurations.py
@@ -1,4 +1,4 @@
-from .ReleaseDetails import ReleaseDetails
+from .DeploymentDetails import DeploymentDetails
 
 
 class RunConfigurations:
@@ -25,10 +25,10 @@ class RunConfigurations:
   :type VIA_ENV_LATEST_RELEASE: bool
   :param via_env_source_name:
   :type VIA_ENV_SOURCE_NAME: str
-  :param release_details:
-  :type release_details: list[ReleaseDetails]
+  :param deployment_details:
+  :type deployment_details: list[DeploymentDetails]
   """
-  def __init__(self, explicit_release_values: dict, crucial_release_definitions: list[str], organization_url: str, personal_access_token: str, queries: list[str], release_name_format: str, release_target_env: str, search_only: bool, via_env: bool, via_env_latest_release: bool, via_env_source_name: str, release_details: list[ReleaseDetails]):
+  def __init__(self, explicit_release_values: dict, crucial_release_definitions: list[str], organization_url: str, personal_access_token: str, queries: list[str], release_name_format: str, release_target_env: str, search_only: bool, via_env: bool, via_env_latest_release: bool, via_env_source_name: str, deployment_details: list[DeploymentDetails]):
     self.EXPLICIT_RELEASE_VALUES = explicit_release_values
     self.CRUCIAL_RELEASE_DEFINITIONS = crucial_release_definitions
     self.ORGANIZATION_URL = organization_url
@@ -40,18 +40,18 @@ class RunConfigurations:
     self.VIA_ENV = via_env
     self.VIA_ENV_LATEST_RELEASE = via_env_latest_release
     self.VIA_ENV_SOURCE_NAME = via_env_source_name
-    self.release_details = release_details
+    self.deployment_details = deployment_details
 
   # Used mainly for testing to reverse map values for an api call
   def to_dict_with_lowercase_keys(self):
-    release_details_dicts = []
+    deployment_details_dicts = []
 
-    if self.release_details: 
-      for release in self.release_details:
-        release_details_dicts.append(release.__dict__)
+    if self.deployment_details: 
+      for deployment in self.deployment_details:
+        deployment_details_dicts.append(deployment.__dict__)
 
     lowered_dict_values = {k.lower(): v for k, v in self.__dict__.items()} 
-    lowered_dict_values['release_details'] = release_details_dicts
+    lowered_dict_values['deployment_details'] = deployment_details_dicts
     
     return lowered_dict_values
 

--- a/ado_express_api/tests/search_views/via_latest_test.py
+++ b/ado_express_api/tests/search_views/via_latest_test.py
@@ -6,7 +6,7 @@ from django.test.client import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 
 from api.search_views import search_via_latest_release
-from base.models.ReleaseDetails import ReleaseDetails
+from base.models.DeploymentDetails import DeploymentDetails
 from base.models.RunConfigurations import RunConfigurations
 
 
@@ -25,7 +25,7 @@ class SearchViaLatestRelease(unittest.TestCase):
     @patch('ado_express.main.Startup.initialize_logging', return_value=None)
     def test_api_call(self, initialize_logging_mock, load_dependencies_mock, get_deployment_detail_from_latest_release_mock):
             # Arrange
-            release_details = ReleaseDetails(self.fake.name(), self.fake.name(), 123, 132, False)
+            release_details = DeploymentDetails(self.fake.name(), self.fake.name(), 123, 132, False)
             run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,True,self.fake.name(), [release_details, release_details, release_details])
             # Conversion needed to enable 
 
@@ -50,7 +50,7 @@ class SearchViaLatestRelease(unittest.TestCase):
 
     def test_api_call_with_missing_field(self):
             # Arrange
-            release_details = ReleaseDetails(self.fake.name(), None, None, None, False) # Missing release_name
+            release_details = DeploymentDetails(self.fake.name(), None, None, None, False) # Missing release_name
             run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,False,self.fake.name(), [release_details])
 
             request = self.factory.post('/search/via-latest', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')

--- a/ado_express_api/tests/search_views/via_number_test.py
+++ b/ado_express_api/tests/search_views/via_number_test.py
@@ -1,0 +1,63 @@
+import json
+import unittest
+from faker import Faker
+from mock import patch
+from django.test.client import RequestFactory
+from django.contrib.auth.models import AnonymousUser
+
+from api.search_views import search_via_release_number
+from base.models.ReleaseDetails import ReleaseDetails
+from base.models.RunConfigurations import RunConfigurations
+
+
+class Empty:
+    pass
+
+
+class SearchViaLatestRelease(unittest.TestCase):
+     
+    def setUp(self):
+        self.fake = Faker()
+        self.factory = RequestFactory()
+        
+    @patch('ado_express.main.Startup.search_and_log_details_only')
+    @patch('ado_express.main.Startup.load_dependencies', return_value=None)
+    @patch('ado_express.main.Startup.initialize_logging', return_value=None)
+    def test_api_call(self, initialize_logging_mock, load_dependencies_mock, get_deployment_detail_from_latest_release_mock):
+            # Arrange
+            release_details = ReleaseDetails(self.fake.name(), self.fake.name(), 123, 132, False)
+            run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,True,self.fake.name(), [release_details, release_details, release_details])
+            # Conversion needed to enable 
+
+            deployment = Empty()
+            deployment.release_project_name = self.fake.name()
+            deployment.release_name = self.fake.name()
+            deployment.release_number = self.fake.random_int()
+            deployment.release_rollback = self.fake.random_int()
+            deployment.is_crucial = False
+
+            get_deployment_detail_from_latest_release_mock.return_value = deployment
+
+            request = self.factory.post('/search/via-number', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
+            request.user = AnonymousUser()
+
+            # Act
+            response = search_via_release_number(request)
+
+            # Assert
+            self.assertEqual(response.data, {'releases': json.dumps([deployment.__dict__, deployment.__dict__, deployment.__dict__])})
+            self.assertEqual(response.status_code, 200)
+
+    def test_api_call_with_missing_field(self):
+            # Arrange
+            release_details = ReleaseDetails(self.fake.name(), None, None, None, False) # Missing release_name
+            run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,False,self.fake.name(), [release_details])
+
+            request = self.factory.post('/search/via-number', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
+            request.user = AnonymousUser()
+
+            # Act
+            response = search_via_release_number(request)
+
+            # Assert
+            self.assertEqual(response.status_code, 400)

--- a/ado_express_api/tests/search_views/via_number_test.py
+++ b/ado_express_api/tests/search_views/via_number_test.py
@@ -6,7 +6,7 @@ from django.test.client import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 
 from api.search_views import search_via_release_number
-from base.models.ReleaseDetails import ReleaseDetails
+from base.models.DeploymentDetails import DeploymentDetails
 from base.models.RunConfigurations import RunConfigurations
 
 
@@ -25,7 +25,7 @@ class SearchViaLatestRelease(unittest.TestCase):
     @patch('ado_express.main.Startup.initialize_logging', return_value=None)
     def test_api_call(self, initialize_logging_mock, load_dependencies_mock, get_deployment_detail_from_latest_release_mock):
             # Arrange
-            release_details = ReleaseDetails(self.fake.name(), self.fake.name(), 123, 132, False)
+            release_details = DeploymentDetails(self.fake.name(), self.fake.name(), 123, 132, False)
             run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,True,self.fake.name(), [release_details, release_details, release_details])
             # Conversion needed to enable 
 
@@ -50,7 +50,7 @@ class SearchViaLatestRelease(unittest.TestCase):
 
     def test_api_call_with_missing_field(self):
             # Arrange
-            release_details = ReleaseDetails(self.fake.name(), None, None, None, False) # Missing release_name
+            release_details = DeploymentDetails(self.fake.name(), None, None, None, False) # Missing release_name
             run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,False,self.fake.name(), [release_details])
 
             request = self.factory.post('/search/via-number', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')

--- a/ado_express_api/tests/search_views/via_number_test.py
+++ b/ado_express_api/tests/search_views/via_number_test.py
@@ -1,9 +1,11 @@
+import datetime
 import json
 import unittest
 from faker import Faker
 from mock import patch
 from django.test.client import RequestFactory
 from django.contrib.auth.models import AnonymousUser
+from base.models.ReleaseDetails import ReleaseDetails
 
 from api.search_views import search_via_release_number
 from base.models.DeploymentDetails import DeploymentDetails
@@ -23,29 +25,28 @@ class SearchViaLatestRelease(unittest.TestCase):
     @patch('ado_express.main.Startup.search_and_log_details_only')
     @patch('ado_express.main.Startup.load_dependencies', return_value=None)
     @patch('ado_express.main.Startup.initialize_logging', return_value=None)
-    def test_api_call(self, initialize_logging_mock, load_dependencies_mock, get_deployment_detail_from_latest_release_mock):
+    def test_api_call(self, initialize_logging_mock, load_dependencies_mock, search_and_log_details_only_mock):
             # Arrange
             release_details = DeploymentDetails(self.fake.name(), self.fake.name(), 123, 132, False)
-            run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,True,self.fake.name(), [release_details, release_details, release_details])
+            run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,True,self.fake.name(), [release_details, release_details])
             # Conversion needed to enable 
 
-            deployment = Empty()
-            deployment.release_project_name = self.fake.name()
-            deployment.release_name = self.fake.name()
-            deployment.release_number = self.fake.random_int()
-            deployment.release_rollback = self.fake.random_int()
-            deployment.is_crucial = False
+            release = ReleaseDetails(release_details.release_project_name, release_details.release_name, self.fake.name(), self.fake.name(), True, datetime.datetime.now())
 
-            get_deployment_detail_from_latest_release_mock.return_value = deployment
+            returned_releases = [release, release, release]
+            search_and_log_details_only_mock.return_value = returned_releases
 
             request = self.factory.post('/search/via-number', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
             request.user = AnonymousUser()
+
+            returned_results = [dict({'release_definition': release_details.release_name, 'release_name': release_details.release_number, 'results': [release.__dict__ for release in returned_releases]}), 
+                                dict({'release_definition': release_details.release_name, 'release_name': release_details.release_number, 'results': [release.__dict__ for release in returned_releases]})]
 
             # Act
             response = search_via_release_number(request)
 
             # Assert
-            self.assertEqual(response.data, {'releases': json.dumps([deployment.__dict__, deployment.__dict__, deployment.__dict__])})
+            self.assertEqual(response.data, {'releases': json.dumps(returned_results, default=str) })
             self.assertEqual(response.status_code, 200)
 
     def test_api_call_with_missing_field(self):

--- a/ado_express_api/tests/search_views/via_query_test.py
+++ b/ado_express_api/tests/search_views/via_query_test.py
@@ -36,7 +36,7 @@ class SearchViaQuery(unittest.TestCase):
             deployment_details = [deployment, deployment, deployment]
             get_deployment_details_from_query_mock.return_value = deployment_details
 
-            request = self.factory.post('/search/query', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
+            request = self.factory.post('/search/via-query', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
             request.user = AnonymousUser()
 
             # Act
@@ -50,7 +50,7 @@ class SearchViaQuery(unittest.TestCase):
         # Arrange
         run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),"",True,True,False,"", [])
 
-        request = self.factory.post('/search/query', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
+        request = self.factory.post('/search/via-query', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
         request.user = AnonymousUser()
 
         # Act

--- a/ado_express_api/tests/search_views/via_query_test.py
+++ b/ado_express_api/tests/search_views/via_query_test.py
@@ -24,7 +24,7 @@ class SearchViaQuery(unittest.TestCase):
     @patch('ado_express.main.Startup.initialize_logging', return_value=None)
     def test_api_call(self, initialize_logging_mock, load_dependencies_mock, get_deployment_details_from_query_mock):
             # Arrange
-            run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,False,self.fake.name(), [])
+            run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),self.fake.name(),True,True,False,self.fake.name(),[])
 
             deployment = Empty()
             deployment.release_project_name = self.fake.name()
@@ -48,7 +48,7 @@ class SearchViaQuery(unittest.TestCase):
     
     def test_api_call_with_missing_fields(self):
         # Arrange
-        run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),"",True,True,False,"", [])
+        run_configurations = RunConfigurations({},[],self.fake.name(),self.fake.name(),[self.fake.name()],self.fake.name(),"",True,True,False,"",[])
 
         request = self.factory.post('/search/via-query', json.dumps(run_configurations.to_dict_with_lowercase_keys()), content_type='application/json')
         request.user = AnonymousUser()


### PR DESCRIPTION
* Cleanup via-latest & query search api input model requirements

* Add empty via-number endpoint & unit tests

* Convert ReleaseDetails into DeploymentDetails

* Complete via-number search endpoint

* Update search via-number tests to match endpoint